### PR TITLE
catch attribute errors

### DIFF
--- a/python/gen3authz/client/arborist/client.py
+++ b/python/gen3authz/client/arborist/client.py
@@ -60,7 +60,7 @@ class ArboristResponse(object):
             return None
         try:
             return self.json["error"]["message"]
-        except KeyError:
+        except (KeyError, AttributeError):
             return self._response.text
 
 

--- a/python/gen3authz/client/arborist/client.py
+++ b/python/gen3authz/client/arborist/client.py
@@ -49,7 +49,10 @@ class ArboristResponse(object):
 
     @property
     def successful(self):
-        return "error" not in self.json
+        try:
+            return "error" not in self.json
+        except AttributeError:
+            return self.code < 400
 
     @property
     def error_msg(self):


### PR DESCRIPTION

### Bug Fixes
catch attribute errors in ArboristResponse when there is no json
