### PR TITLE
Revert "feat(jwt): add default jwt (#10)"

### DIFF
--- a/python/gen3authz/client/arborist/client.py
+++ b/python/gen3authz/client/arborist/client.py
@@ -3,8 +3,6 @@ Define the ArboristClient class for interfacing with the arborist service for
 authz.
 """
 
-import flask
-
 from functools import wraps
 
 try:
@@ -166,21 +164,11 @@ class ArboristClient(AuthzClient):
         return response.json
 
     @_arborist_retry()
-    def auth_request(self, service, methods, resources, jwt=None):
+    def auth_request(self, jwt, service, methods, resources):
         """
         Return:
             bool: authorization response
         """
-        # try to default
-        if not jwt:
-            auth_header = flask.request.headers.get("Authorization")
-            if auth_header:
-                items = auth_header.split(" ")
-                if len(items) == 2 and items[0].lower() == "bearer":
-                    jwt = items[1]
-        # ok, now we complain
-        if not jwt:
-            raise ArboristError("couldn't get JWT from authorization header")
         if isinstance(resources, string_types):
             resources = [resources]
         if isinstance(methods, string_types):

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,5 +31,5 @@ setup(
     url="https://github.com/uc-cdis/gen3authz",
     license="Apache",
     packages=find_packages(),
-    install_requires=["cdiserrors~=0.1", "backoff~=1.6", "requests~=2.18", "Flask"],
+    install_requires=["cdiserrors~=0.1", "backoff~=1.6", "requests~=2.18"],
 )


### PR DESCRIPTION
This reverts commit dffa3dd66101f541daa020a3fdcd3e0aedc2d3e3 (https://github.com/uc-cdis/gen3authz/pull/10), so as not to end up with Flask as a dependency in what is meant to be a generic Python client library. 


### Breaking Changes
auth_request signature has reverted

### Improvements
remove default jwt arg to auth_request that just gets jwt from flask.request.headers

### Dependency updates
No longer require Flask
