### PR TITLE
test(urls): Move client url tests from fence

### DIFF
--- a/python/tests/arborist/test_urls.py
+++ b/python/tests/arborist/test_urls.py
@@ -1,0 +1,50 @@
+"""
+Run some basic tests that the methods on ``ArboristClient`` actually try to hit
+the correct URLs on the arborist API.
+"""
+
+from unittest import mock
+
+
+def test_healthy_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.get") as mock_get:
+        arborist_client.healthy()
+        assert mock_get.called_with(arborist_client._base_url + "/health")
+
+
+def test_get_resource_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.get") as mock_get:
+        arborist_client.get_resource("/a/b/c")
+        assert mock_get.called_with(arborist_client._base_url + "/resource/a/b/c")
+
+
+def test_list_policies_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.get") as mock_get:
+        arborist_client.list_policies()
+        assert mock_get.called_with(arborist_client._base_url + "/policy/")
+
+
+def test_policies_not_exist_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.get") as mock_get:
+        arborist_client.policies_not_exist(["foo-bar"])
+        assert mock_get.called_with(arborist_client._base_url + "/policy/")
+
+
+def test_create_resource_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.post") as mock_post:
+        arborist_client.create_resource("/", {"name": "test"})
+        assert mock_post.called_with(arborist_client._base_url + "/resource/")
+
+
+def test_create_role_call(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.post") as mock_post:
+        arborist_client.create_role({"id": "test"})
+        assert mock_post.called_with(arborist_client._base_url + "/role/")
+
+
+def test_create_policy(arborist_client):
+    with mock.patch("gen3authz.client.arborist.client.requests.post") as mock_post:
+        arborist_client.create_role(
+            {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
+        )
+        assert mock_post.called_with(arborist_client._base_url + "/policy/")

--- a/python/tests/arborist/test_urls.py
+++ b/python/tests/arborist/test_urls.py
@@ -3,8 +3,12 @@ Run some basic tests that the methods on ``ArboristClient`` actually try to hit
 the correct URLs on the arborist API.
 """
 
-from unittest import mock
-
+try:
+    # python3
+    from unittest import mock
+except ImportError:
+    # python2
+    import mock
 
 def test_healthy_call(arborist_client):
     with mock.patch("gen3authz.client.arborist.client.requests.get") as mock_get:


### PR DESCRIPTION
### Improvements
Move some Arborist client tests from Fence to this package

