### PR TITLE
added veracode scanning files for Jenkins security pipeline

### DIFF
--- a/.secexclude
+++ b/.secexclude
@@ -1,0 +1,11 @@
+.github/*
+python/tests/*
+python/CHANGELOG.md
+python/README.md
+python/test-requirements.txt
+pull_request_template.md
+README.md
+LICENSE
+NOTICE
+.travis.yml
+.gitignore

--- a/.secinclude
+++ b/.secinclude
@@ -1,0 +1,5 @@
+python/gen3authz/*
+python/setup.py
+python/th_wrapper.py
+python/Pipfile
+python/Pipfile.lock

--- a/Jenkinsfile.security
+++ b/Jenkinsfile.security
@@ -1,0 +1,6 @@
+#!groovy
+
+@Library('cdis-jenkins-lib@master') _
+
+securityPipeline {
+}


### PR DESCRIPTION
This commit simply adds 3 files that are needed to perform scheduled scans of this repository through the Jenkins security organization pipeline.

### New Features
- Added .secinclude to include all relevant files needed for veracode scan.
- Added .secexclude to explicitly remove any unneeded files.
- Added Jenkinsfile.security for the veracode security organization in Jenkins to scan this repo regularly.