### PR TITLE
Fix 'object dict can't be used in 'await' expression'

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen3authz"
-version = "1.0.4"
+version = "1.0.5"
 description = "Gen3 authz client"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
during usersync:
```Traceback (most recent call last):
  File "/usr/local/bin/fence-create", line 5, in <module>
    main()
  File "/fence/bin/fence_create.py", line 474, in main
    fallback_to_dbgap_sftp=fallback_to_dbgap_sftp,
  File "/fence/fence/scripting/fence_create.py", line 337, in sync_users
    syncer.sync()
  File "/fence/fence/sync/sync_users.py", line 1255, in sync
    self._sync(s)
  File "/fence/fence/sync/sync_users.py", line 1385, in _sync
    success = self._update_authz_in_arborist(sess, user_projects, user_yaml)
  File "/fence/fence/sync/sync_users.py", line 1732, in _update_authz_in_arborist
    client.client_id, client_policies
  File "/usr/local/lib/python3.6/site-packages/gen3authz/utils.py", line 20, in _wrapper
    result = coro.send(result)
  File "/usr/local/lib/python3.6/site-packages/gen3authz/client/arborist/base.py", line 843, in update_client
    await self.create_client(client_id, policies)
TypeError: object dict can't be used in 'await' expression
```
i suspect caused by awaiting a function with "maybe_sync" decorator when not using async

### Bug Fixes
- Fix 'object dict can't be used in 'await' expression' error
