### PR TITLE
Only await healthy() if the client is async

### DIFF
--- a/python/src/gen3authz/client/arborist/base.py
+++ b/python/src/gen3authz/client/arborist/base.py
@@ -194,9 +194,11 @@ class BaseArboristClient(AuthzClient):
                         for n in backoff.fibo():
                             yield n / 2.0
 
-                    await backoff.on_predicate(wait_gen, on_giveup=giveup, **retry)(
+                    res = backoff.on_predicate(wait_gen, on_giveup=giveup, **retry)(
                         self.healthy
                     )()
+                    if inspect.isawaitable(res):
+                        res = await res
                     rv = await client.request(method, url, **kwargs)
                 else:
                     raise


### PR DESCRIPTION
Attempt at fixing this bug when arborist is not healthy and gen3authz retries:

```
Traceback (most recent call last):
  File "/usr/local/bin/fence-create", line 5, in <module>
    main()
  File "/fence/bin/fence_create.py", line 474, in main
    fallback_to_dbgap_sftp=fallback_to_dbgap_sftp,
  File "/fence/fence/scripting/fence_create.py", line 337, in sync_users
    syncer.sync()
  File "/fence/fence/sync/sync_users.py", line 1257, in sync
    self._sync(s)
  File "/fence/fence/sync/sync_users.py", line 1375, in _sync
    success = self._update_arborist(sess, user_yaml)
  File "/fence/fence/sync/sync_users.py", line 1496, in _update_arborist
    self.arborist_client.update_resource("/", resource)
  File "/usr/local/lib/python3.6/site-packages/gen3authz/utils.py", line 20, in _wrapper
    result = coro.send(result)
  File "/usr/local/lib/python3.6/site-packages/gen3authz/client/arborist/base.py", line 415, in update_resource
    response = await self.put(url, json=resource_json)
  File "/usr/local/lib/python3.6/site-packages/gen3authz/client/arborist/base.py", line 197, in request
    self.healthy
TypeError: object bool can't be used in 'await' expression
```

### Bug Fixes
- During retries, only await `healthy()` if the client is async
