### PR TITLE
(PXP-9503): Fix @maybe_sync decorator so that it honors synchronous clients

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen3authz"
-version = "1.5.0"
+version = "1.5.1"
 description = "Gen3 authz client"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/python/src/gen3authz/client/arborist/client.py
+++ b/python/src/gen3authz/client/arborist/client.py
@@ -30,3 +30,6 @@ class ArboristClient(BaseArboristClient):
     """
 
     client_cls = SyncClient
+
+    def _is_async(self):
+        return False

--- a/python/tests/arborist/conftest.py
+++ b/python/tests/arborist/conftest.py
@@ -18,7 +18,7 @@ def arborist_base_url():
     return ""
 
 
-@pytest.fixture(scope="session", params=["async", ""])
+@pytest.fixture(scope="session", params=["async", "sync"])
 def use_async(request):
     return request.param == "async"
 

--- a/python/tests/arborist/test_auth_request.py
+++ b/python/tests/arborist/test_auth_request.py
@@ -4,16 +4,14 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_auth_request_positive(arborist_client, mock_arborist_request):
+async def test_auth_request_positive(arborist_client, mock_arborist_request, use_async):
     mock_arborist_request({"/auth/request": {"POST": (200, {"auth": True})}})
-    assert await arborist_client.auth_request(
-        "", "fence", "file_upload", "/data_upload"
-    )
-
-
-@pytest.mark.parametrize("use_async", [False], indirect=["use_async"])
-def test_sync_auth_request_positive(arborist_client, mock_arborist_request, use_async):
-    mock_arborist_request({"/auth/request": {"POST": (200, {"auth": True})}})
-    assert (
-        arborist_client.auth_request("", "fence", "file_upload", "/data_upload") is True
-    )
+    if use_async:
+        assert await arborist_client.auth_request(
+            "", "fence", "file_upload", "/data_upload"
+        )
+    else:
+        assert (
+            arborist_client.auth_request("", "fence", "file_upload", "/data_upload")
+            is True
+        )

--- a/python/tests/arborist/test_health.py
+++ b/python/tests/arborist/test_health.py
@@ -3,11 +3,19 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_health_endpoint(arborist_client, mock_arborist_request):
+async def test_health_endpoint(arborist_client, mock_arborist_request, use_async):
     mock_arborist_request({"/health": {"GET": (200, "OK")}})
-    assert await arborist_client.healthy()
+    if use_async:
+        assert await arborist_client.healthy()
+    else:
+        assert arborist_client.healthy()
 
 
-async def test_health_endpoint_unhealthy(arborist_client, mock_arborist_request):
+async def test_health_endpoint_unhealthy(
+    arborist_client, mock_arborist_request, use_async
+):
     mock_arborist_request({"/health": {"GET": (400, "unhealthy")}})
-    assert not await arborist_client.healthy()
+    if use_async:
+        assert not await arborist_client.healthy()
+    else:
+        assert not arborist_client.healthy()

--- a/python/tests/arborist/test_urls.py
+++ b/python/tests/arborist/test_urls.py
@@ -9,9 +9,12 @@ from gen3authz.client.arborist.errors import ArboristError
 pytestmark = pytest.mark.asyncio
 
 
-async def test_get_resource_call(arborist_client, mock_arborist_request):
+async def test_get_resource_call(arborist_client, mock_arborist_request, use_async):
     mock_get = mock_arborist_request({"/resource/a/b/c": {"GET": (200, {"is": 789})}})
-    assert await arborist_client.get_resource("/a/b/c") == {"is": 789}
+    if use_async:
+        assert await arborist_client.get_resource("/a/b/c") == {"is": 789}
+    else:
+        assert arborist_client.get_resource("/a/b/c") == {"is": 789}
     mock_get.assert_called_with(
         "get",
         arborist_client._base_url + "/resource/a/b/c",
@@ -21,9 +24,12 @@ async def test_get_resource_call(arborist_client, mock_arborist_request):
     )
 
 
-async def test_list_policies_call(arborist_client, mock_arborist_request):
+async def test_list_policies_call(arborist_client, mock_arborist_request, use_async):
     mock_get = mock_arborist_request({"/policy/": {"GET": (200, {"is": 789})}})
-    assert await arborist_client.list_policies() == {"is": 789}
+    if use_async:
+        assert await arborist_client.list_policies() == {"is": 789}
+    else:
+        assert arborist_client.list_policies() == {"is": 789}
     mock_get.assert_called_with(
         "get",
         arborist_client._base_url + "/policy/",
@@ -33,9 +39,14 @@ async def test_list_policies_call(arborist_client, mock_arborist_request):
     )
 
 
-async def test_policies_not_exist_call(arborist_client, mock_arborist_request):
+async def test_policies_not_exist_call(
+    arborist_client, mock_arborist_request, use_async
+):
     mock_get = mock_arborist_request({"/policy/": {"GET": (200, {"is": 789})}})
-    assert await arborist_client.policies_not_exist(["foo-bar"]) == ["foo-bar"]
+    if use_async:
+        assert await arborist_client.policies_not_exist(["foo-bar"]) == ["foo-bar"]
+    else:
+        assert arborist_client.policies_not_exist(["foo-bar"]) == ["foo-bar"]
     mock_get.assert_called_with(
         "get",
         arborist_client._base_url + "/policy/",
@@ -45,9 +56,14 @@ async def test_policies_not_exist_call(arborist_client, mock_arborist_request):
     )
 
 
-async def test_create_resource_call(arborist_client, mock_arborist_request):
+async def test_create_resource_call(arborist_client, mock_arborist_request, use_async):
     mock_post = mock_arborist_request({"/resource/": {"POST": (200, {"is": 789})}})
-    assert await arborist_client.create_resource("/", {"name": "test"}) == {"is": 789}
+    if use_async:
+        assert await arborist_client.create_resource("/", {"name": "test"}) == {
+            "is": 789
+        }
+    else:
+        assert arborist_client.create_resource("/", {"name": "test"}) == {"is": 789}
     mock_post.assert_called_with(
         "post",
         arborist_client._base_url + "/resource/",
@@ -57,9 +73,12 @@ async def test_create_resource_call(arborist_client, mock_arborist_request):
     )
 
 
-async def test_create_role_call(arborist_client, mock_arborist_request):
+async def test_create_role_call(arborist_client, mock_arborist_request, use_async):
     mock_post = mock_arborist_request({"/role/": {"POST": (200, {"is": 789})}})
-    assert await arborist_client.create_role({"id": "test"}) == {"is": 789}
+    if use_async:
+        assert await arborist_client.create_role({"id": "test"}) == {"is": 789}
+    else:
+        assert arborist_client.create_role({"id": "test"}) == {"is": 789}
     mock_post.assert_called_with(
         "post",
         arborist_client._base_url + "/role/",
@@ -69,11 +88,16 @@ async def test_create_role_call(arborist_client, mock_arborist_request):
     )
 
 
-async def test_create_policy(arborist_client, mock_arborist_request):
+async def test_create_policy(arborist_client, mock_arborist_request, use_async):
     mock_post = mock_arborist_request({"/policy/": {"POST": (200, {"is": 789})}})
-    assert await arborist_client.create_policy(
-        {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
-    ) == {"is": 789}
+    if use_async:
+        assert await arborist_client.create_policy(
+            {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
+        ) == {"is": 789}
+    else:
+        assert arborist_client.create_policy(
+            {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
+        ) == {"is": 789}
     mock_post.assert_called_with(
         "post",
         arborist_client._base_url + "/policy/",
@@ -83,12 +107,19 @@ async def test_create_policy(arborist_client, mock_arborist_request):
     )
 
 
-async def test_create_policy_with_ctx(arborist_client, mock_arborist_request):
+async def test_create_policy_with_ctx(
+    arborist_client, mock_arborist_request, use_async
+):
     mock_post = mock_arborist_request({"/policy/": {"POST": (200, {"is": 789})}})
     with arborist_client.context(authz_provider="ttt"):
-        assert await arborist_client.create_policy(
-            {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
-        ) == {"is": 789}
+        if use_async:
+            assert await arborist_client.create_policy(
+                {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
+            ) == {"is": 789}
+        else:
+            assert arborist_client.create_policy(
+                {"id": "test", "resource_paths": ["/"], "role_ids": ["test"]}
+            ) == {"is": 789}
     mock_post.assert_called_with(
         "post",
         arborist_client._base_url + "/policy/",
@@ -99,7 +130,7 @@ async def test_create_policy_with_ctx(arborist_client, mock_arborist_request):
     )
 
 
-async def test_grant_user_policy(arborist_client, mock_arborist_request):
+async def test_grant_user_policy(arborist_client, mock_arborist_request, use_async):
     username = "johnsmith"
     expires_at = int(
         datetime.datetime(
@@ -115,12 +146,20 @@ async def test_grant_user_policy(arborist_client, mock_arborist_request):
     mock_post = mock_arborist_request(
         {f"/user/{username}/policy": {"POST": (204, None)}}
     )
-    assert (
-        await arborist_client.grant_user_policy(
-            username, "test_policy", expires_at=expires_at
+    if use_async:
+        assert (
+            await arborist_client.grant_user_policy(
+                username, "test_policy", expires_at=expires_at
+            )
+            == 204
         )
-        == 204
-    )
+    else:
+        assert (
+            arborist_client.grant_user_policy(
+                username, "test_policy", expires_at=expires_at
+            )
+            == 204
+        )
     mock_post.assert_called_with(
         "post",
         arborist_client._base_url + f"/user/{username}/policy",
@@ -130,14 +169,19 @@ async def test_grant_user_policy(arborist_client, mock_arborist_request):
     )
 
 
-async def test_update_user(arborist_client, mock_arborist_request):
+async def test_update_user(arborist_client, mock_arborist_request, use_async):
     username = "johnsmith"
     new_username = "janesmith"
     new_email = "janesmith@domain.tld"
     mock_post = mock_arborist_request({f"/user/{username}": {"PATCH": (204, None)}})
-    response = await arborist_client.update_user(
-        username, new_username=new_username, new_email=new_email
-    )
+    if use_async:
+        response = await arborist_client.update_user(
+            username, new_username=new_username, new_email=new_email
+        )
+    else:
+        response = arborist_client.update_user(
+            username, new_username=new_username, new_email=new_email
+        )
     assert response.code == 204
     mock_post.assert_called_with(
         "patch",
@@ -148,11 +192,16 @@ async def test_update_user(arborist_client, mock_arborist_request):
     )
 
 
-async def test_update_user_raises_error(arborist_client, mock_arborist_request):
+async def test_update_user_raises_error(
+    arborist_client, mock_arborist_request, use_async
+):
     username = "johnsmith"
     new_username = "janesmith"
     mock_post = mock_arborist_request({f"/user/{username}": {"PATCH": (500, None)}})
     with pytest.raises(ArboristError):
-        response = await arborist_client.update_user(
-            username, new_username=new_username
-        )
+        if use_async:
+            response = await arborist_client.update_user(
+                username, new_username=new_username
+            )
+        else:
+            response = arborist_client.update_user(username, new_username=new_username)


### PR DESCRIPTION
Jira Ticket: [PXP-9503](https://ctds-planx.atlassian.net/browse/PXP-9503)

Although access token polling runs at the top level with asyncio, the portion of the code syncing authz information to Arborist imports the synchronous gen3authz client and does **not** await the gen3authz methods used. Because gen3authz's `@maybe_sync` decorator infers whether a method should be synchronous vs asynchronous based on whether sniffio finds an asynchronous library, the result is that when running access token polling, the Fence sync code thinks it is calling a synchronous gen3authz method while gen3authz thinks the method being called is an async function. This means that access token polling fails to sync authz information to Arborist.

Logs are in the ticket.

### Bug Fixes
- Fix `@maybe_sync` decorator so that it honors synchronous clients
- Fix synchronous unit tests not to await