### PR TITLE
Add expires to bulk policy grant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen3authz"
-version = "2.2.0"
+version = "2.3.0"
 description = "Gen3 authz client"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/src/gen3authz/client/arborist/base.py
+++ b/src/gen3authz/client/arborist/base.py
@@ -846,14 +846,18 @@ class BaseArboristClient(AuthzClient):
         return True
 
     @maybe_sync
-    async def grant_bulk_user_policy(self, username, policy_ids):
+    async def grant_bulk_user_policy(self, username, policy_ids, expires_at=None):
         """
         MUST be user name, and not serial user ID
         """
         url = self._user_url + "/{}/bulk/policy".format(quote(username))
         request = []
         for policy_id in policy_ids:
-            request.append({"policy": policy_id})
+            policy_request = {"policy": policy_id}
+            if expires_at is not None:
+                expires = datetime.datetime.utcfromtimestamp(expires_at)
+                policy_request["expires_at"] = expires.isoformat() + "Z"
+            request.append(policy_request)
         response = await self.post(url, json=request, expect_json=False)
         if response.code != 204:
             self.logger.error(

--- a/tests/arborist/test_urls.py
+++ b/tests/arborist/test_urls.py
@@ -170,6 +170,51 @@ async def test_grant_user_policy(arborist_client, mock_arborist_request, use_asy
     )
 
 
+async def test_grant_bulk_user_policy(
+    arborist_client, mock_arborist_request, use_async
+):
+    username = "johnsmith"
+    expires_at = int(
+        datetime.datetime(
+            year=2021,
+            month=11,
+            day=23,
+            hour=9,
+            minute=30,
+            second=1,
+            tzinfo=datetime.timezone.utc,
+        ).timestamp()
+    )
+    print(expires_at)
+    mock_post = mock_arborist_request(
+        {f"/user/{username}/bulk/policy": {"POST": (204, None)}}
+    )
+    if use_async:
+        assert (
+            await arborist_client.grant_bulk_user_policy(
+                username, ["test_policy 1", "test_policy 2"], expires_at=expires_at
+            )
+            == 204
+        )
+    else:
+        assert (
+            arborist_client.grant_bulk_user_policy(
+                username, ["test_policy 1", "test_policy 2"], expires_at=expires_at
+            )
+            == 204
+        )
+    mock_post.assert_called_with(
+        "post",
+        arborist_client._base_url + f"/user/{username}/bulk/policy",
+        data=None,
+        json=[
+            {"policy": "test_policy 1", "expires_at": "2021-11-23T09:30:01Z"},
+            {"policy": "test_policy 2", "expires_at": "2021-11-23T09:30:01Z"},
+        ],
+        timeout=10,
+    )
+
+
 async def test_update_user(arborist_client, mock_arborist_request, use_async):
     username = "johnsmith"
     new_username = "janesmith"


### PR DESCRIPTION


Link to JIRA ticket if there is one: 

### New Features
- Updates bulk policy grant to include an expires_at, similar to single policy grant.
### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
