### PR TITLE
Don't expect JSON when deleting resource

### DIFF
--- a/src/gen3authz/client/arborist/base.py
+++ b/src/gen3authz/client/arborist/base.py
@@ -526,7 +526,7 @@ class BaseArboristClient(AuthzClient):
     @maybe_sync
     async def delete_resource(self, path):
         url = self._resource_url + quote(path)
-        response = await self.delete(url)
+        response = await self.delete(url, expect_json=False)
         if response.code not in [204, 404]:
             msg = "could not delete resource `{}` in arborist: {}".format(
                 path, response.error_msg

--- a/tests/arborist/conftest.py
+++ b/tests/arborist/conftest.py
@@ -52,7 +52,11 @@ def mock_arborist_request(request, arborist_base_url, use_async):
             else:
                 code, content = response_mapping[url][method]
                 mocked_response.status_code = code
-                if isinstance(content, dict):
+                # Handle 204 No Content - calling .json() should raise ValueError
+                if code == 204:
+                    mocked_response.text = ""
+                    mocked_response.json.side_effect = ValueError("No JSON content in 204 response")
+                elif isinstance(content, dict):
                     mocked_response.json.return_value = content
                 else:
                     mocked_response.text = content

--- a/tests/arborist/test_urls.py
+++ b/tests/arborist/test_urls.py
@@ -25,6 +25,42 @@ async def test_get_resource_call(arborist_client, mock_arborist_request, use_asy
         timeout=10,
     )
 
+async def test_delete_resource_call(arborist_client, mock_arborist_request, use_async):
+    mock_delete = mock_arborist_request({"/resource/a/b/c": {"DELETE": (204, None)}})
+    if use_async:
+        assert await arborist_client.delete_resource("/a/b/c") == True
+    else:
+        assert arborist_client.delete_resource("/a/b/c") == True
+    mock_delete.assert_called_with(
+        "delete",
+        arborist_client._base_url + "/resource/a/b/c",
+        timeout=10,
+    )
+async def test_delete_resource_call_404_response(arborist_client, mock_arborist_request, use_async):
+    mock_delete = mock_arborist_request({"/resource/a/b/c": {"DELETE": (404, "this is the 404 response")}})
+    if use_async:
+        assert await arborist_client.delete_resource("/a/b/c") == True
+    else:
+        assert arborist_client.delete_resource("/a/b/c") == True
+    mock_delete.assert_called_with(
+        "delete",
+        arborist_client._base_url + "/resource/a/b/c",
+        timeout=10,
+    )
+async def test_delete_resource_call_other_response_code(arborist_client, mock_arborist_request, use_async):
+    mock_delete = mock_arborist_request({"/resource/a/b/c": {"DELETE": (500, "this is the other response code")}})
+    if use_async:
+        with pytest.raises(ArboristError):
+            assert await arborist_client.delete_resource("/a/b/c") == True
+    else:
+        with pytest.raises(ArboristError):
+            assert arborist_client.delete_resource("/a/b/c") == True
+    mock_delete.assert_called_with(
+        "delete",
+        arborist_client._base_url + "/resource/a/b/c",
+        timeout=10,
+    )
+
 
 async def test_list_policies_call(arborist_client, mock_arborist_request, use_async):
     mock_get = mock_arborist_request({"/policy/": {"GET": (200, {"is": 789})}})


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

Pass expect_json=False to self.delete() in delete_resource so the client doesn't try to parse JSON for delete responses (commonly 204 No Content or 404). This prevents JSON parsing errors and lets the code handle response.code as intended.


### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
